### PR TITLE
support windows and modify function's arguments' type check algorithm

### DIFF
--- a/weave/ast.go
+++ b/weave/ast.go
@@ -9,8 +9,12 @@ import (
 
 // stolen from http://golang.org/src/cmd/fix/fix.go
 func isPkgDot(expr ast.Expr, pkg, name string) bool {
-	sel, ok := expr.(*ast.SelectorExpr)
-	return ok && isIdent(sel.X, pkg) && isIdent(sel.Sel, name)
+	if len(pkg) > 0 {
+		sel, ok := expr.(*ast.SelectorExpr)
+		return ok && isIdent(sel.X, pkg) && isIdent(sel.Sel, name)
+	} else {
+		return isIdent(expr, name)
+	}
 }
 
 // stolen from http://golang.org/src/cmd/fix/fix.go
@@ -42,58 +46,74 @@ func parseExpr(s string) ast.Expr {
 // 2) order of arguments
 // 3) no args
 // 4) no simple args
-func containArgs(pk string, p []*ast.Field) bool {
+func containArgs(pk string, fn *ast.FuncDecl) bool {
+
+	/*
+		this function will return a channel through which
+		we can get every argument's type of pfn
+	*/
+	nextarg := func(pfn *ast.FuncDecl, stop chan int) <-chan ast.Expr {
+		argTypeChnl := make(chan ast.Expr)
+		go func() {
+			defer close(argTypeChnl)
+			for _, arg := range pfn.Type.Params.List {
+				for range arg.Names {
+					select {
+					case argTypeChnl <- arg.Type:
+					case <-stop:
+						return
+					}
+				}
+			}
+		}()
+		return argTypeChnl
+	}
+
+	stop := make(chan int)
+	defer close(stop)
+
+	argTypeChnl := nextarg(fn, stop)
+
+	//--------------------
 
 	pk = strings.Split(pk, "(")[1]
 	pk = strings.Split(pk, ")")[0]
 
-	argz := strings.Split(pk, ",")
+	arglist := strings.Split(pk, ",")
 
-	if (len(argz) == 1) && (argz[0] == "") {
-		argz = []string{}
+	if (len(arglist) == 1) && (arglist[0] == "") {
+		arglist = []string{}
 	}
 
-	// early bail if mis-matched argc
-	if len(argz) != len(p) {
-		return false
-	}
+	// Check whether every argument's type is the same
+	for _, argtype := range arglist {
 
-	xtrue := 0
+		typelist := strings.Split(argtype, ".")
+		isptr := (argtype[0] == '*')
 
-	// for now we ignore simple args like string, int
-	// also - these are un-ordered right now..
-	// also - no support for no args
-	for i := 0; i < len(argz); i++ {
-		if strings.Contains(argz[i], ".") {
-			s := strings.Split(argz[i], ".")
-			pkg := strings.TrimSpace(s[0])
-			iname := strings.TrimSpace(s[1])
+		pkg := ""
+		name := typelist[0]
 
-			if strings.Contains(pkg, "*") {
-				pkg = strings.Replace(pkg, "*", "", -1)
-				for _, field := range p {
-					if isPtrPkgDot(field.Type, pkg, iname) {
-						xtrue += 1
-					}
-				}
+		compareArgType := isPkgDot
+		if isptr {
+			compareArgType = isPtrPkgDot
+		}
 
-			} else {
-				for _, field := range p {
-
-					if isPkgDot(field.Type, pkg, iname) {
-						xtrue += 1
-					}
-				}
+		// pkg.type or *pkg.type
+		if len(typelist) == 2 {
+			pkg = typelist[0]
+			name = typelist[1]
+			if isptr {
+				pkg = pkg[1:]
 			}
+		}
 
-		} else {
-			xtrue += 1
+		nextArgType, ok := <-argTypeChnl
+
+		if !ok || !compareArgType(nextArgType, pkg, name) {
+			return false
 		}
 	}
 
-	if xtrue == len(argz) {
-		return true
-	}
-
-	return false
+	return true
 }

--- a/weave/build.go
+++ b/weave/build.go
@@ -1,129 +1,149 @@
 package weave
 
 import (
+	"fmt"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+)
+
+type osCmdInfo struct {
+	shell  []string // Shell命令
+	mkdir  string
+	rmdir  string
+	pwd    string
+	cp     string
+	xcp    string
+	exeext string // 可执行文件扩展名
+	envsep string // GOPATH环境变量中用来分隔不同路径的字符
+}
+
+var (
+	oscmdenv *osCmdInfo
 )
 
 // buildDir determines what the root build dir is
 func (w *Weave) buildDir() string {
-	out, err := exec.Command("bash", "-c", "pwd").CombinedOutput()
-	if err != nil {
-		w.flog.Println(err.Error())
-	}
+	return buildDir()
+}
 
-	return strings.TrimSpace(string(out))
+func execShellCmd(cmd string) (out []byte, err error) {
+	arglist := append(oscmdenv.shell, cmd)
+	out, err = exec.Command(arglist[0], arglist[1:]...).CombinedOutput()
+	if err != nil {
+		log.Printf("\ncmd: %s\nerr: %v\n", cmd, err)
+	}
+	return
 }
 
 // buildDir determines what the root build dir is
 func buildDir() string {
-	out, err := exec.Command("bash", "-c", "pwd").CombinedOutput()
-	if err != nil {
-		log.Println(err.Error())
-	}
-
+	out, _ := execShellCmd(oscmdenv.pwd)
 	return strings.TrimSpace(string(out))
 }
 
 // binName returns the expected bin name
 func (w *Weave) binName() string {
 	s := w.buildDir()
-	stuff := strings.Split(s, "/")
-	return stuff[len(stuff)-1]
+	stuff := strings.Split(s, string(filepath.Separator))
+	return stuff[len(stuff)-1] + oscmdenv.exeext
 }
 
 // whichgo determines provides the full go path to the current go build
 // tool
 func (w *Weave) whichGo() string {
-	out, err := exec.Command("bash", "-c", "which go").CombinedOutput()
-	if err != nil {
-		w.flog.Println(err.Error())
-	}
-
-	return strings.TrimSpace(string(out))
+	return "go"
 }
 
 // tmpLocation returns the tmp build dir
 func (w *Weave) tmpLocation() string {
-	out, err := exec.Command("bash", "-c", "echo $GOPATH").CombinedOutput()
-	if err != nil {
-		w.flog.Println(err.Error())
-	}
-
-	return string(out) + "src/_weave" + w.buildDir()
+	return tmpLocation()
 }
 
-// tmpLocation returns the tmp build dir
 func tmpLocation() string {
-	out, err := exec.Command("bash", "-c", "echo $GOPATH").CombinedOutput()
-	if err != nil {
-		log.Println(err.Error())
+	gopath := os.Getenv("GOPATH")
+	if idx := strings.Index(gopath, oscmdenv.envsep); idx > 0 {
+		gopath = gopath[:idx]
 	}
-
-	return strings.TrimSpace(string(out)) + "/src/_weave/" + setBase()
+	return filepath.Join(gopath, "src", "_weave", setBase())
 }
 
 // build does the actual compilation
 // right nowe we piggy back off of 6g/8g
 func (w *Weave) build() {
-	buildstr := "cd " + w.buildLocation + " && " + w.whichGo() + " build && cp " +
-		w.binName() + " " + w.buildDir() + "/."
 
-	o, err := exec.Command("bash", "-c", buildstr).CombinedOutput()
+	idx := strings.Index(w.buildLocation, "_weave")
+	weavedir := w.buildLocation[:idx+6]
+	defer os.RemoveAll(weavedir)
+
+	delbin := fmt.Sprintf("%s %s", oscmdenv.rmdir, filepath.Join(w.buildLocation, w.binName()))
+	execShellCmd(delbin)
+
+	buildstr := "cd " + w.buildLocation
+	buildstr += " && " + w.whichGo() + " build "
+	buildstr += fmt.Sprintf(" && %s %s %s", oscmdenv.cp, w.binName(), w.buildDir())
+
+	o, err := execShellCmd(buildstr)
 	if err != nil {
 		w.flog.Println(string(o))
 	}
-
 }
 
 // prep prepares any tmp. build dirs
 func (w *Weave) prep() {
 
 	// hacky dir prep
-	fstcmd := "mkdir -p " + w.buildLocation
-	sndcmd := `find . -type d -exec mkdir -p "` + w.buildLocation + `/{}" \;`
+	os.RemoveAll(w.buildLocation)
+	fstcmd := fmt.Sprintf("%s %s", oscmdenv.mkdir, w.buildLocation)
 
 	// hack to get anything that might be ref'd in the env
-	hackcmd := `cp -R * ` + w.buildLocation
+	hackcmd := fmt.Sprintf("%s * %s", oscmdenv.xcp, w.buildLocation)
 
-	_, err := exec.Command("bash", "-c", fstcmd).CombinedOutput()
+	_, err := execShellCmd(fstcmd)
 	if err != nil {
-		w.flog.Println(err.Error())
+		w.flog.Println(fstcmd, err.Error())
 	}
 
-	_, err = exec.Command("bash", "-c", sndcmd).CombinedOutput()
-	if err != nil {
-		w.flog.Println(err.Error())
-	}
+	filepath.Walk(
+		w.buildLocation,
+		func(fname string, fi os.FileInfo, err error) error {
+			if fi == nil || err != nil {
+				return err
+			} else if !fi.IsDir() || fi.Name() == "." || fi.Name() == ".." {
+				return nil
+			} else {
+				mkdir := fmt.Sprintf("%s %s", oscmdenv.mkdir, filepath.Join(w.buildLocation, fi.Name()))
+				execShellCmd(mkdir)
+				return nil
+			}
+		},
+	)
 
-	_, err = exec.Command("bash", "-c", hackcmd).CombinedOutput()
+	_, err = execShellCmd(hackcmd)
 	if err != nil {
-		w.flog.Println(err.Error())
+		w.flog.Println(hackcmd, err.Error())
 	}
-
 }
 
 // rootPkg returns the root package of a go build
 // this is needed to determine whether or not sub-pkg imports need to be
 // re-written - which is basically any project w/more than one folder
 func (w *Weave) rootPkg() string {
-	out, err := exec.Command("bash", "-c", "go list").CombinedOutput()
-	if err != nil {
-		w.flog.Println(err.Error())
-	}
-
-	return strings.TrimSpace(string(out))
+	return setBase()
 }
 
 // rootPkg returns the root package of a go build
 // this is needed to determine whether or not sub-pkg imports need to be
 // re-written - which is basically any project w/more than one folder
 func setBase() string {
-	out, err := exec.Command("bash", "-c", "go list").CombinedOutput()
+	out, err := exec.Command("go", "list").CombinedOutput()
 	if err != nil {
 		log.Println(err.Error())
 	}
 
-	return strings.TrimSpace(string(out))
+	str := strings.TrimSpace(string(out))
+	str = filepath.FromSlash(str)
+	return str
 }

--- a/weave/build_darwin.go
+++ b/weave/build_darwin.go
@@ -1,0 +1,13 @@
+package weave
+
+func init() {
+	oscmdenv = &osCmdInfo{
+		shell:  []string{"/bin/sh", "-c"},
+		mkdir:  "mkdir -p",
+		rmdir:  "rm -rf",
+		pwd:    "pwd",
+		cp:     "cp",
+		xcp:    "cp -r",
+		envsep: ":",
+	}
+}

--- a/weave/build_linux.go
+++ b/weave/build_linux.go
@@ -1,0 +1,13 @@
+package weave
+
+func init() {
+	oscmdenv = &osCmdInfo{
+		shell:  []string{"/bin/sh", "-c"},
+		mkdir:  "mkdir -p",
+		rmdir:  "rm -rf",
+		pwd:    "pwd",
+		cp:     "cp",
+		xcp:    "cp -r",
+		envsep: ":",
+	}
+}

--- a/weave/build_windows.go
+++ b/weave/build_windows.go
@@ -1,0 +1,14 @@
+package weave
+
+func init() {
+	oscmdenv = &osCmdInfo{
+		shell:  []string{"cmd", "/e:on", "/c"},
+		mkdir:  "mkdir",
+		rmdir:  "rmdir /s /q",
+		pwd:    "cd",
+		cp:     "copy",
+		xcp:    "xcopy /e /q",
+		exeext: ".exe",
+		envsep: ";",
+	}
+}

--- a/weave/pointcut.go
+++ b/weave/pointcut.go
@@ -14,15 +14,6 @@ type Pointcut struct {
 	kind     int
 }
 
-// pointCutType returns a map of id to human expression of pointcut types
-func pointCutType() map[int]string {
-	return map[int]string{
-		1: "call",
-		2: "execution",
-		3: "within",
-	}
-}
-
 // set def extracts the joinpoint from a pointcut definition
 func setDef(t string) (int, string, error) {
 

--- a/weave/transform.go
+++ b/weave/transform.go
@@ -86,7 +86,7 @@ func (w *Weave) applyCallAdvice(fname string, stuff string) string {
 		fset := token.NewFileSet()
 		file, err := parser.ParseFile(fset, fname, rout, parser.Mode(0))
 		if err != nil {
-			w.flog.Println("Failed to parse source: %s", err.Error())
+			w.flog.Println("Failed to parse source:", err.Error())
 		}
 
 		// look for call expressions - call joinpoints
@@ -336,7 +336,7 @@ func (w *Weave) applyExecutionJP(fname string, stuff string) string {
 				fpk = fn.Name.Name
 			}
 
-			if fn.Name.Name == fpk && containArgs(pk, fn) {
+			if fn.Name.Name == fpk && containArgs(pk, fn.Type.Params.List) {
 
 				// begin line
 				begin := fset.Position(fn.Body.Lbrace).Line

--- a/weave/transform.go
+++ b/weave/transform.go
@@ -336,7 +336,7 @@ func (w *Weave) applyExecutionJP(fname string, stuff string) string {
 				fpk = fn.Name.Name
 			}
 
-			if fn.Name.Name == fpk && containArgs(pk, fn.Type.Params.List) {
+			if fn.Name.Name == fpk && containArgs(pk, fn) {
 
 				// begin line
 				begin := fset.Position(fn.Body.Lbrace).Line

--- a/weave/weave.go
+++ b/weave/weave.go
@@ -74,6 +74,10 @@ func (w *Weave) Run() {
 // this is fairly heavy/expensive/pos right now
 func (w *Weave) VisitFile(fp string, fi os.FileInfo, err error) error {
 
+	if fi == nil || err != nil {
+		return err
+	}
+
 	matched, err := filepath.Match("*.go", fi.Name())
 	if err != nil {
 		w.flog.Println(err)

--- a/weave/weave_test.go
+++ b/weave/weave_test.go
@@ -2,6 +2,7 @@ package weave
 
 import (
 	"go/ast"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -34,7 +35,7 @@ func main() {
 `
 	w := NewWeave()
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -49,7 +50,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyAroundAdvice("/tmp/blah")
+	after := w.applyAroundAdvice(os.TempDir() + "/blah")
 
 	if after != expected {
 		t.Error(after)
@@ -89,7 +90,7 @@ func main() {
 	time.Sleep(1 * time.Second)
 }`
 
-	w.writeOut("/tmp/blah_test_go", f1)
+	w.writeOut(os.TempDir()+"/blah_test_go", f1)
 
 	aspect2 := Aspect{
 		advize: Advice{
@@ -108,7 +109,7 @@ func main() {
 
 	rootpkg := w.rootPkg()
 
-	after, _ := w.processGoRoutines("/tmp/blah_test_go", rootpkg)
+	after, _ := w.processGoRoutines(os.TempDir()+"/blah_test_go", rootpkg)
 
 	expected :=
 		`package main
@@ -207,7 +208,7 @@ func main() {
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -224,7 +225,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyExecutionJP("/tmp/blah", f1)
+	after := w.applyExecutionJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -268,7 +269,7 @@ fmt.Println("before main")
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -284,7 +285,7 @@ fmt.Println("before main")
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyExecutionJP("/tmp/blah", f1)
+	after := w.applyExecutionJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -327,7 +328,7 @@ func main() {
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -343,7 +344,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyExecutionJP("/tmp/blah", f1)
+	after := w.applyExecutionJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -386,7 +387,7 @@ func main() {
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -402,7 +403,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyExecutionJP("/tmp/blah", f1)
+	after := w.applyExecutionJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -447,7 +448,7 @@ func main() {
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -463,7 +464,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyExecutionJP("/tmp/blah", f1)
+	after := w.applyExecutionJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error("##" + after + "##")
@@ -507,7 +508,7 @@ func main() {
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -524,7 +525,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyExecutionJP("/tmp/blah", f1)
+	after := w.applyExecutionJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -569,7 +570,7 @@ func main() {
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -585,7 +586,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyExecutionJP("/tmp/blah", f1)
+	after := w.applyExecutionJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -628,7 +629,7 @@ func main() {
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -644,7 +645,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyExecutionJP("/tmp/blah", f1)
+	after := w.applyExecutionJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -695,7 +696,7 @@ func main() {
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -711,7 +712,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyExecutionJP("/tmp/blah", f1)
+	after := w.applyExecutionJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -758,7 +759,7 @@ fmt.Println("before call")
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -774,7 +775,7 @@ fmt.Println("before call")
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyCallAdvice("/tmp/blah", f1)
+	after := w.applyCallAdvice(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -825,7 +826,7 @@ fmt.Println("strconv called")
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -841,7 +842,7 @@ fmt.Println("strconv called")
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyCallAdvice("/tmp/blah", f1)
+	after := w.applyCallAdvice(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -864,9 +865,9 @@ func main() {
 	s := "github.com/some/stuff"
 
 	w := NewWeave()
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
-	af := w.ParseAST("/tmp/blah")
+	af := w.ParseAST(os.TempDir() + "/blah")
 
 	pruned := w.pruneImports(af, s)
 
@@ -919,14 +920,14 @@ fmt.Println(myCnt)
 
 	w := NewWeave()
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
 			before: "myCnt += 1",
 		},
 		pointkut: Pointcut{
-			def:  "getStuff(int i)",
+			def:  "getStuff(int)",
 			kind: 2,
 		},
 	}
@@ -958,7 +959,7 @@ fmt.Println(myCnt)
 
 	w.aspects = aspects
 
-	fp := "/tmp/blah"
+	fp := os.TempDir() + "/blah"
 	stuff := w.applyGlobalAdvice(fp, f1)
 	w.writeOut(fp, stuff)
 
@@ -1007,7 +1008,7 @@ fmt.Println("strconv called")
 
 	w := NewWeave()
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -1023,7 +1024,7 @@ fmt.Println("strconv called")
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyCallAdvice("/tmp/blah", f1)
+	after := w.applyCallAdvice(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -1063,7 +1064,7 @@ strconv.Itoa(2))
 
 	w := NewWeave()
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -1079,7 +1080,7 @@ strconv.Itoa(2))
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyCallAdvice("/tmp/blah", f1)
+	after := w.applyCallAdvice(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -1119,7 +1120,7 @@ fmt.Println("strconv called")
 
 	w := NewWeave()
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -1135,7 +1136,7 @@ fmt.Println("strconv called")
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyCallAdvice("/tmp/blah", f1)
+	after := w.applyCallAdvice(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)
@@ -1185,7 +1186,7 @@ fmt.Println("strconv called")
 
 	w := NewWeave()
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -1201,7 +1202,7 @@ fmt.Println("strconv called")
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyCallAdvice("/tmp/blah", f1)
+	after := w.applyCallAdvice(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(printWLines(after))
@@ -1244,7 +1245,7 @@ fmt.Println("query took %d seconds", t)
 
 	w := NewWeave()
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -1271,7 +1272,7 @@ fmt.Println("query took %d seconds", t)
 	aspects = append(aspects, aspect2)
 	w.aspects = aspects
 
-	after := w.applyCallAdvice("/tmp/blah", f1)
+	after := w.applyCallAdvice(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(printWLines(after))
@@ -1316,7 +1317,7 @@ fmt.Println("query took %d seconds", t)
 
 	w := NewWeave()
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -1343,7 +1344,7 @@ fmt.Println("query took %d seconds", t)
 	aspects = append(aspects, aspect2)
 	w.aspects = aspects
 
-	after := w.applyCallAdvice("/tmp/blah", f1)
+	after := w.applyCallAdvice(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(printWLines(after))

--- a/weave/within.go
+++ b/weave/within.go
@@ -46,7 +46,7 @@ func (w *Weave) applyWithinJP(fname string, stuff string) string {
 				fpk = fn.Name.Name
 			}
 
-			if fn.Name.Name == fpk && containArgs(pk, fn.Type.Params.List) {
+			if fn.Name.Name == fpk && containArgs(pk, fn) {
 
 				wb := WithinBlock{
 					name:          fn.Name.Name,

--- a/weave/within.go
+++ b/weave/within.go
@@ -46,7 +46,7 @@ func (w *Weave) applyWithinJP(fname string, stuff string) string {
 				fpk = fn.Name.Name
 			}
 
-			if fn.Name.Name == fpk && containArgs(pk, fn) {
+			if fn.Name.Name == fpk && containArgs(pk, fn.Type.Params.List) {
 
 				wb := WithinBlock{
 					name:          fn.Name.Name,

--- a/weave/within_test.go
+++ b/weave/within_test.go
@@ -1,6 +1,7 @@
 package weave
 
 import (
+	"os"
 	"testing"
 )
 
@@ -62,7 +63,7 @@ func main() {
 
 	w := &Weave{}
 
-	w.writeOut("/tmp/blah", f1)
+	w.writeOut(os.TempDir()+"/blah", f1)
 
 	aspect := Aspect{
 		advize: Advice{
@@ -79,7 +80,7 @@ func main() {
 	aspects = append(aspects, aspect)
 	w.aspects = aspects
 
-	after := w.applyWithinJP("/tmp/blah", f1)
+	after := w.applyWithinJP(os.TempDir()+"/blah", f1)
 
 	if after != expected {
 		t.Error(after)


### PR DESCRIPTION
1 Add support of Windows
2 Modify the function's argument type compare algorithm
(in function "containeArgs" at weave/ast.go)
check function's every argument,include the arguments not use package.

For example:
func blah(a, b string, x int) error {
fmt.Println(strconv.Itoa(x))
return nil
}

and the weave file:
aspect {
pointcut: execute(blah(string,string,int) int)
advice: {
before: {
fmt.Println("call blah: x=",x)
}
}
}
3 in weave/weave_test.go and within_test.go:  /tmp ---> os.TempDir() so it can work in both Linux and Windows

I have tested in Linux and Windows,but I have no Darwin system,so it is not tested in Drawin system.